### PR TITLE
Include repl jars in the parcel.

### DIFF
--- a/build_parcel.sh
+++ b/build_parcel.sh
@@ -28,11 +28,13 @@ cd ../
 
 mkdir -p ./$PARCEL_DIR/jars
 mkdir -p ./$PARCEL_DIR/repl-jars
+mkdir -p ./$PARCEL_DIR/rsc-jars
 
 cp -r ./livy/bin ./$PARCEL_DIR/
 cp -r ./livy/conf ./$PARCEL_DIR/
 cp ./livy/server/target/jars/*.jar ./$PARCEL_DIR/jars/
 cp ./livy/repl/target/jars/*.jar ./$PARCEL_DIR/repl-jars/
+cp ./livy/rsc/target/jars/*.jar ./$PARCEL_DIR/rsc-jars/
 
 # Download logback jar
 wget -O ./$PARCEL_DIR/jars/logback-classic.jar http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar

--- a/build_parcel.sh
+++ b/build_parcel.sh
@@ -27,10 +27,12 @@ cd ../
 [ ! -d ./$PARCEL_DIR ] && rm -rf ./$PARCEL_DIR
 
 mkdir -p ./$PARCEL_DIR/jars
+mkdir -p ./$PARCEL_DIR/repl-jars
 
 cp -r ./livy/bin ./$PARCEL_DIR/
 cp -r ./livy/conf ./$PARCEL_DIR/
 cp ./livy/server/target/jars/*.jar ./$PARCEL_DIR/jars/
+cp ./livy/repl/target/jars/*.jar ./$PARCEL_DIR/repl-jars/
 
 # Download logback jar
 wget -O ./$PARCEL_DIR/jars/logback-classic.jar http://central.maven.org/maven2/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar


### PR DESCRIPTION
I'm getting an error response from our Livy service like: `requirement failed: Cannot find Livy REPL jars.`

I looked in the Livy source and found the cause of that error: https://github.com/cloudera/livy/blob/2d6e0267f344c2cd7c9df779ec788160a1c7014b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala#L312

This change should ensure that the repl jars exist.
